### PR TITLE
Localtool: Autoreload of testdll directly before starting tests

### DIFF
--- a/RegTesting.LocalTest/GUI/MainWindow.xaml.cs
+++ b/RegTesting.LocalTest/GUI/MainWindow.xaml.cs
@@ -340,6 +340,8 @@ namespace RegTesting.LocalTest.GUI
 			string testsystem = txtTestsystem.Text;
 			string fileName = txtFile.Text;
 
+			LoadTestcaseFile(txtFile.Text);
+
 			if(selectedBrowsersLocal.Any())
 				TestLocal(testsystem,selectedBrowsersLocal,selectedTestcases,selectedLanguages);
 


### PR DESCRIPTION
Reloads testfile before starting tests to ensure that always the latest version is used.
Implements #18
