### PR TITLE
PageObjectFactory: Derivates for PageElements and fix missing baseUrl

### DIFF
--- a/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedButton.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedButton.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageElements
+{
+	class DerivedButton : Button
+	{
+		public DerivedButton(By byLocator, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentBasePageObject, ClickBehaviours clickBehaviour = ClickBehaviours.Default) : base(byLocator, webDriver, waitModel, parentBasePageObject, clickBehaviour)
+		{
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedCheckBox.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedCheckBox.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageElements
+{
+	class DerivedCheckBox : CheckBox
+	{
+		public DerivedCheckBox(By byLocator, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ClickBehaviours clickBehaviour = ClickBehaviours.Default) : base(byLocator, webDriver, waitModel, parentPageObject, clickBehaviour)
+		{
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedHiddenElement.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedHiddenElement.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageElements
+{
+	class DerivedHiddenElement : HiddenElement
+	{
+		public DerivedHiddenElement(By byLocator, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ClickBehaviours clickBehaviour = ClickBehaviours.Default) : base(byLocator, webDriver, waitModel, parentPageObject, clickBehaviour)
+		{
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedImage.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedImage.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageElements
+{
+	class DerivedImage : Image
+	{
+		public DerivedImage(By byLocator, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ClickBehaviours clickBehaviour = ClickBehaviours.Default) : base(byLocator, webDriver, waitModel, parentPageObject, clickBehaviour)
+		{
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedInput.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedInput.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageElements
+{
+	class DerivedInput : Input
+	{
+		public DerivedInput(By objBy, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ClickBehaviours clickBehaviour = ClickBehaviours.Default, FillBehaviour fillBehaviour = FillBehaviour.Default) : base(objBy, webDriver, waitModel, parentPageObject, clickBehaviour, fillBehaviour)
+		{
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedLink.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedLink.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageElements
+{
+	class DerivedLink : Link
+	{
+		public DerivedLink(By objBy, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ClickBehaviours clickBehaviour = ClickBehaviours.Default) : base(objBy, webDriver, waitModel, parentPageObject, clickBehaviour)
+		{
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedSelectBox.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageElements/DerivedSelectBox.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageElements
+{
+	class DerivedSelectBox : SelectBox
+	{
+		public DerivedSelectBox(By objBy, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ISelectable selectBehaviour = null) : base(objBy, webDriver, waitModel, parentPageObject, selectBehaviour)
+		{
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageObjectFactoryTest.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageObjectFactoryTest.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Logic;
+using RegTesting.Tests.Framework.UnitTests.PageElements;
+using RegTesting.Tests.Framework.UnitTests.PageObjects;
+
+namespace RegTesting.Tests.Framework.UnitTests
+{
+	[TestClass]
+	public class PageObjectFactoryTest
+	{
+
+		/// <summary>
+		/// The PageObjectFactory should be able to create an empty PageObject.
+		/// </summary>
+		[TestMethod]
+		public void ShouldBeAbleToCreateEmptyPageObject()
+		{
+			EmptyPageObject emptyPageObject = PageObjectFactory.GetPageObjectByType<EmptyPageObject>(null);
+
+			Assert.AreEqual(emptyPageObject.GetType(), typeof(EmptyPageObject));
+		}
+
+		/// <summary>
+		/// The PageObjectFactory should be able to create a PageObject with just a BasicPageElement.
+		/// </summary>
+		[TestMethod]
+		public void ShouldBeAbleToCreatePageObjectWithBasicPageElement()
+		{
+			BasicPageObject basicPageObject = PageObjectFactory.GetPageObjectByType<BasicPageObject>(null);
+
+			Assert.AreEqual(basicPageObject.GetType(), typeof(BasicPageObject));
+			Assert.AreEqual(basicPageObject.Element.GetType(), typeof(BasicPageElement));
+
+		}
+
+		/// <summary>
+		/// The PageObjectFactory should be able to create a PageObject with default page elements.
+		/// </summary>
+		[TestMethod]
+		public void ShouldBeAbleToCreatePageObjectWithDefaultPageElements()
+		{
+			DefaultElementsPageObject defaultElementsPageObject = PageObjectFactory.GetPageObjectByType<DefaultElementsPageObject>(null);
+
+			Assert.AreEqual(defaultElementsPageObject.GetType(), typeof(DefaultElementsPageObject));
+			Assert.AreEqual(defaultElementsPageObject.ButtonElement.GetType(), typeof(Button));
+			Assert.AreEqual(defaultElementsPageObject.CheckBoxElement.GetType(), typeof(CheckBox));
+			Assert.AreEqual(defaultElementsPageObject.HiddenElement.GetType(), typeof(HiddenElement));
+			Assert.AreEqual(defaultElementsPageObject.ImageElement.GetType(), typeof(Image));
+			Assert.AreEqual(defaultElementsPageObject.InputElement.GetType(), typeof(Input));
+			Assert.AreEqual(defaultElementsPageObject.LinkElement.GetType(), typeof(Link));
+			Assert.AreEqual(defaultElementsPageObject.SelectBoxElement.GetType(), typeof(SelectBox));
+		}
+
+
+		/// <summary>
+		/// The PageObjectFactory should be able to create a PageObject with derived page elements.
+		/// </summary>
+		[TestMethod]
+		public void ShouldBeAbleToCreatePageObjectWithDerivedPageElements()
+		{
+			DerivedElementsPageObject derivedElementsPageObject = PageObjectFactory.GetPageObjectByType<DerivedElementsPageObject>(null);
+
+			Assert.AreEqual(derivedElementsPageObject.GetType(), typeof(DerivedElementsPageObject));
+			Assert.AreEqual(derivedElementsPageObject.BasicPageElement.GetType(), typeof(DerivedBasicPageElement));
+			Assert.AreEqual(derivedElementsPageObject.ButtonElement.GetType(), typeof(DerivedButton));
+			Assert.AreEqual(derivedElementsPageObject.CheckBoxElement.GetType(), typeof(DerivedCheckBox));
+			Assert.AreEqual(derivedElementsPageObject.HiddenElement.GetType(), typeof(DerivedHiddenElement));
+			Assert.AreEqual(derivedElementsPageObject.ImageElement.GetType(), typeof(DerivedImage));
+			Assert.AreEqual(derivedElementsPageObject.InputElement.GetType(), typeof(DerivedInput));
+			Assert.AreEqual(derivedElementsPageObject.LinkElement.GetType(), typeof(DerivedLink));
+			Assert.AreEqual(derivedElementsPageObject.SelectBoxElement.GetType(), typeof(DerivedSelectBox));
+		}
+
+		/// <summary>
+		/// The PageObjectFactory should be able to create a PageObject with an included PageObject that contains another page element.
+		/// </summary>
+		[TestMethod]
+		public void ShouldBeAbleToCreatePageObjectWithIncludedPartialPageObject()
+		{
+			ParentPageObject parentPageObject = PageObjectFactory.GetPageObjectByType<ParentPageObject>(null);
+
+			Assert.AreEqual(parentPageObject.GetType(), typeof(ParentPageObject));
+			Assert.AreEqual(parentPageObject.Element.GetType(), typeof(BasicPageElement));
+			Assert.AreEqual(parentPageObject.ChildPageObject.Element.GetType(), typeof(BasicPageElement));
+
+		}
+	}
+
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageObjects/BasicPageObject.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageObjects/BasicPageObject.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.PageObjects;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageObjects
+{
+	class BasicPageObject : BasePageObject
+	{
+
+		[Locate(How = How.Id, Using = "elementID")]
+		public BasicPageElement Element { get; private set; }
+
+
+		public BasicPageObject(IWebDriver driver) : base(driver)
+		{
+		}
+
+		public override IDictionary<string, object> DefaultPageSettings
+		{
+			get { return null; }
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageObjects/ChildPageObject.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageObjects/ChildPageObject.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.PageObjects;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageObjects
+{
+	class ChildPageObject : BasePageObject
+	{
+
+		[Locate(How = How.Id, Using = "elementID")]
+		public BasicPageElement Element { get; private set; }
+
+
+		public ChildPageObject(IWebDriver driver)
+			: base(driver)
+		{
+		}
+
+		public override IDictionary<string, object> DefaultPageSettings
+		{
+			get { return null; }
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageObjects/DefaultElementsPageObject.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageObjects/DefaultElementsPageObject.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.PageObjects;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageObjects
+{
+	class DefaultElementsPageObject : BasePageObject
+	{
+
+		[Locate(How = How.Id, Using = "InputElement")]
+		public Input InputElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "ImageElement")]
+		public Image ImageElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "LinkElement")]
+		public Link LinkElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "ButtonElement")]
+		public Button ButtonElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "CheckBoxElement")]
+		public CheckBox CheckBoxElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "SelectBoxElement")]
+		public SelectBox SelectBoxElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "HiddenElement")]
+		public HiddenElement HiddenElement { get; private set; }
+
+
+
+
+		public DefaultElementsPageObject(IWebDriver driver)
+			: base(driver)
+		{
+		}
+
+		public override IDictionary<string, object> DefaultPageSettings
+		{
+			get { return null; }
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageObjects/DerivedBasicPageElement.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageObjects/DerivedBasicPageElement.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageObjects
+{
+	class DerivedBasicPageElement : BasicPageElement
+	{
+		public DerivedBasicPageElement(By byLocator, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ClickBehaviours clickBehaviour = ClickBehaviours.Default) : base(byLocator, webDriver, waitModel, parentPageObject, clickBehaviour)
+		{
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageObjects/DerivedElementsPageObject.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageObjects/DerivedElementsPageObject.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.PageObjects;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Logic;
+using RegTesting.Tests.Framework.UnitTests.PageElements;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageObjects
+{
+	class DerivedElementsPageObject : BasePageObject
+	{
+
+		[Locate(How = How.Id, Using = "InputElement")]
+		public DerivedInput InputElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "ImageElement")]
+		public DerivedImage ImageElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "LinkElement")]
+		public DerivedLink LinkElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "ButtonElement")]
+		public DerivedButton ButtonElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "CheckBoxElement")]
+		public DerivedCheckBox CheckBoxElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "SelectBoxElement")]
+		public DerivedSelectBox SelectBoxElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "HiddenElement")]
+		public DerivedHiddenElement HiddenElement { get; private set; }
+
+		[Locate(How = How.Id, Using = "BasicPageElement")]
+		public DerivedBasicPageElement BasicPageElement { get; private set; }
+
+
+		public DerivedElementsPageObject(IWebDriver driver)
+			: base(driver)
+		{
+		}
+
+		public override IDictionary<string, object> DefaultPageSettings
+		{
+			get { return null; }
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageObjects/EmptyPageObject.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageObjects/EmptyPageObject.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageObjects
+{
+	class EmptyPageObject : BasePageObject
+	{
+		public EmptyPageObject(IWebDriver driver) : base(driver)
+		{
+		}
+
+		public override IDictionary<string, object> DefaultPageSettings
+		{
+			get { return null; }
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/PageObjects/ParentPageObject.cs
+++ b/RegTesting.Tests.Framework.UnitTests/PageObjects/ParentPageObject.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.PageObjects;
+using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Logic;
+
+namespace RegTesting.Tests.Framework.UnitTests.PageObjects
+{
+	class ParentPageObject : BasePageObject
+	{
+
+		[PartialPageObject]
+		public BasicPageObject ChildPageObject { get; private set; }
+
+		[Locate(How = How.Id, Using = "someElementID")]
+		public BasicPageElement Element { get; private set; }
+
+
+
+		public ParentPageObject(IWebDriver driver)
+			: base(driver)
+		{
+		}
+
+		public override IDictionary<string, object> DefaultPageSettings
+		{
+			get { return null; }
+		}
+	}
+}

--- a/RegTesting.Tests.Framework.UnitTests/Properties/AssemblyInfo.cs
+++ b/RegTesting.Tests.Framework.UnitTests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("RegTesting.Tests.Framework")]
+[assembly: AssemblyTitle("RegTesting.Tests.Framework.UnitTests")]
 [assembly: AssemblyDescription("A test framework for tests with selenium.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("HOTELDE AG")]
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("a7e6a771-5f9d-425a-a401-3a5f4c71b270")]
+[assembly: Guid("da28c545-1f8d-47f0-964e-69dc4417bc67")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -28,9 +28,9 @@ using System.Runtime.InteropServices;
 //      Minor Version 
 //      Build Number
 //      Revision
-[assembly: AssemblyFileVersion("1.2.2.3")]
-[assembly: AssemblyInformationalVersion("1.2.2.3")]
-
-// Change AssemblyVersion for breaking api changes
-// http://stackoverflow.com/questions/64602/what-are-differences-between-assemblyversion-assemblyfileversion-and-assemblyin
-[assembly: AssemblyVersion("1.2.0.0")]
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RegTesting.Tests.Framework.UnitTests/RegTesting.Tests.Framework.UnitTests.csproj
+++ b/RegTesting.Tests.Framework.UnitTests/RegTesting.Tests.Framework.UnitTests.csproj
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RegTesting.Tests.Framework.UnitTests</RootNamespace>
+    <AssemblyName>RegTesting.Tests.Framework.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="WebDriver">
+      <HintPath>..\packages\Selenium.WebDriver.2.45.0\lib\net40\WebDriver.dll</HintPath>
+    </Reference>
+    <Reference Include="WebDriver.Support, Version=2.45.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Selenium.Support.2.45.0\lib\net40\WebDriver.Support.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="PageElements\DerivedButton.cs" />
+    <Compile Include="PageElements\DerivedCheckBox.cs" />
+    <Compile Include="PageElements\DerivedHiddenElement.cs" />
+    <Compile Include="PageElements\DerivedImage.cs" />
+    <Compile Include="PageElements\DerivedInput.cs" />
+    <Compile Include="PageElements\DerivedLink.cs" />
+    <Compile Include="PageElements\DerivedSelectBox.cs" />
+    <Compile Include="PageObjectFactoryTest.cs" />
+    <Compile Include="PageObjects\BasicPageObject.cs" />
+    <Compile Include="PageObjects\ChildPageObject.cs" />
+    <Compile Include="PageObjects\DerivedBasicPageElement.cs" />
+    <Compile Include="PageObjects\DerivedElementsPageObject.cs" />
+    <Compile Include="PageObjects\DefaultElementsPageObject.cs" />
+    <Compile Include="PageObjects\ParentPageObject.cs" />
+    <Compile Include="PageObjects\EmptyPageObject.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RegTesting.Tests.Framework\RegTesting.Tests.Framework.csproj">
+      <Project>{CF5F9D83-8F58-408E-AE13-1B504353B95E}</Project>
+      <Name>RegTesting.Tests.Framework</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/RegTesting.Tests.Framework.UnitTests/packages.config
+++ b/RegTesting.Tests.Framework.UnitTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Selenium.Support" version="2.45.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="2.45.0" targetFramework="net45" />
+</packages>

--- a/RegTesting.Tests.Framework/Elements/SelectBox.cs
+++ b/RegTesting.Tests.Framework/Elements/SelectBox.cs
@@ -10,10 +10,10 @@ namespace RegTesting.Tests.Framework.Elements
 	{
 		private readonly ISelectable _selectBehaviour;
 
-		public SelectBox(By objBy, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ISelectable clickBehaviour = null)
+		public SelectBox(By objBy, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ISelectable selectBehaviour = null)
 			: base(objBy, webDriver, waitModel, parentPageObject, ClickBehaviours.Default)
 		{
-			_selectBehaviour = clickBehaviour ?? new DefaultSelectBehaviour(this);
+			_selectBehaviour = selectBehaviour ?? new DefaultSelectBehaviour(this);
 		}
 
 

--- a/RegTesting.Tests.Framework/Logic/PageObjectFactory.cs
+++ b/RegTesting.Tests.Framework/Logic/PageObjectFactory.cs
@@ -198,17 +198,19 @@ namespace RegTesting.Tests.Framework.Logic
 				return (BasicPageElement) Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject, clickBehaviours);
 			}
 
+			if ((typeof(Input).IsAssignableFrom(fieldType)))
+			{
+				return (BasicPageElement)Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject, clickBehaviours, fillBehaviour);
+			}
+
+
 			if ((typeof(BasicPageElement).IsAssignableFrom(fieldType)) ||
 				(typeof(SelectBox).IsAssignableFrom(fieldType)))
 			{
 				return (BasicPageElement)Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject);
 			}
 
-			if ((typeof(Input).IsAssignableFrom(fieldType)))
-			{
-				return (BasicPageElement)Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject, clickBehaviours, fillBehaviour);
-			}
-
+	
 			return null;
 		}
 

--- a/RegTesting.Tests.Framework/Logic/PageObjectFactory.cs
+++ b/RegTesting.Tests.Framework/Logic/PageObjectFactory.cs
@@ -183,38 +183,27 @@ namespace RegTesting.Tests.Framework.Logic
 
 		internal static BasicPageElement CreateElementObject(Type fieldType, IWebDriver webDriver, By @by, WaitModel waitModel, BasePageObject parentPageObject, ClickBehaviours clickBehaviours = ClickBehaviours.Default, FillBehaviour fillBehaviour = FillBehaviour.Default)
 		{
-			if (fieldType == typeof (Button))
+
+			if ((typeof(Button).IsAssignableFrom(fieldType)) ||
+				(typeof(Link).IsAssignableFrom(fieldType)) ||
+				(typeof(Image).IsAssignableFrom(fieldType)) ||
+				(typeof(CheckBox).IsAssignableFrom(fieldType)) ||
+				(typeof(HiddenElement).IsAssignableFrom(fieldType)))
 			{
-				return new Button(@by, webDriver, waitModel, parentPageObject, clickBehaviours);
+				return (BasicPageElement) Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject, clickBehaviours);
 			}
-			if (fieldType == typeof (Link))
+
+			if ((typeof(BasicPageElement).IsAssignableFrom(fieldType)) ||
+				(typeof(SelectBox).IsAssignableFrom(fieldType)))
 			{
-				return new Link(@by, webDriver, waitModel, parentPageObject, clickBehaviours);
+				return (BasicPageElement)Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject);
 			}
-			if (fieldType == typeof(Image))
+
+			if ((typeof(Input).IsAssignableFrom(fieldType)))
 			{
-				return new Image(@by, webDriver, waitModel, parentPageObject, clickBehaviours);
+				return (BasicPageElement)Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject, clickBehaviours, fillBehaviour);
 			}
-			if (fieldType == typeof(BasicPageElement))
-			{
-				return new BasicPageElement(@by, webDriver, waitModel, parentPageObject);
-			}
-			if (fieldType == typeof(SelectBox))
-			{
-				return new SelectBox(@by, webDriver, waitModel, parentPageObject);
-			}
-			if (fieldType == typeof(CheckBox))
-			{
-				return new CheckBox(@by, webDriver, waitModel, parentPageObject, clickBehaviours);
-			}
-			if (fieldType == typeof(Input))
-			{
-				return new Input(@by, webDriver, waitModel, parentPageObject, clickBehaviours, fillBehaviour);
-			}
-			if (fieldType == typeof(HiddenElement))
-			{
-				return new HiddenElement(@by, webDriver, waitModel, parentPageObject, clickBehaviours);
-			}
+
 			return null;
 		}
 

--- a/RegTesting.Tests.Framework/Logic/PageObjectFactory.cs
+++ b/RegTesting.Tests.Framework/Logic/PageObjectFactory.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
-using System.Threading;
 using OpenQA.Selenium;
 using RegTesting.Tests.Framework.Elements;
 using RegTesting.Tests.Framework.Enums;
@@ -195,19 +195,31 @@ namespace RegTesting.Tests.Framework.Logic
 				(typeof(CheckBox).IsAssignableFrom(fieldType)) ||
 				(typeof(HiddenElement).IsAssignableFrom(fieldType)))
 			{
-				return (BasicPageElement) Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject, clickBehaviours);
+				return (BasicPageElement)Activator.CreateInstance(fieldType,
+					BindingFlags.CreateInstance |
+					BindingFlags.Public |
+					BindingFlags.Instance |
+					BindingFlags.OptionalParamBinding, null, new object[] { @by, webDriver, waitModel, parentPageObject, clickBehaviours }, CultureInfo.CurrentCulture);
 			}
 
 			if ((typeof(Input).IsAssignableFrom(fieldType)))
 			{
-				return (BasicPageElement)Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject, clickBehaviours, fillBehaviour);
+				return (BasicPageElement)Activator.CreateInstance(fieldType,
+					BindingFlags.CreateInstance |
+					BindingFlags.Public |
+					BindingFlags.Instance |
+					BindingFlags.OptionalParamBinding, null, new object[] { @by, webDriver, waitModel, parentPageObject, clickBehaviours, fillBehaviour }, CultureInfo.CurrentCulture);
 			}
 
 
 			if ((typeof(BasicPageElement).IsAssignableFrom(fieldType)) ||
 				(typeof(SelectBox).IsAssignableFrom(fieldType)))
 			{
-				return (BasicPageElement)Activator.CreateInstance(fieldType, @by, webDriver, waitModel, parentPageObject);
+				return (BasicPageElement) Activator.CreateInstance(fieldType,
+					BindingFlags.CreateInstance |
+					BindingFlags.Public |
+					BindingFlags.Instance |
+					BindingFlags.OptionalParamBinding, null, new object[] { @by, webDriver, waitModel, parentPageObject }, CultureInfo.CurrentCulture);
 			}
 
 	

--- a/RegTesting.Tests.Framework/Logic/PageObjectFactory.cs
+++ b/RegTesting.Tests.Framework/Logic/PageObjectFactory.cs
@@ -28,7 +28,12 @@ namespace RegTesting.Tests.Framework.Logic
 		public static T CreateAndNavigateTo<T>(IWebDriver webDriver, string baseUrl, IDictionary<string, object> pageSettings = null, params string[] furtherUrlParameters) where T : BasePageObject
 		{
 			T pageObject = CreatePageObject<T>(webDriver);
-			String pageUrl = pageObject.CreatePageUrl(furtherUrlParameters);
+
+			String pageUrl = baseUrl;
+			if (!pageUrl.EndsWith("/"))
+				pageUrl = pageUrl + "/";
+				
+			pageUrl = pageUrl +	pageObject.CreatePageUrl(furtherUrlParameters);
 			TestLog.AddWithoutTime("<br><b>>>>" + typeof(T).Name + "</b>");
 			TestLog.Add("CreateAndNavigate: " + typeof(T).Name + " -> " + pageUrl);
 			webDriver.Navigate().GoToUrl(pageUrl);

--- a/RegTesting.Tests.Framework/Properties/AssemblyInfo.cs
+++ b/RegTesting.Tests.Framework/Properties/AssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 //      Minor Version 
 //      Build Number
 //      Revision
-[assembly: AssemblyFileVersion("1.2.1.0")]
-[assembly: AssemblyInformationalVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.2.0")]
+[assembly: AssemblyInformationalVersion("1.2.2.0")]
 
 // Change AssemblyVersion for breaking api changes
 // http://stackoverflow.com/questions/64602/what-are-differences-between-assemblyversion-assemblyfileversion-and-assemblyin

--- a/RegTesting.Tests.Framework/Properties/AssemblyInfo.cs
+++ b/RegTesting.Tests.Framework/Properties/AssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 //      Minor Version 
 //      Build Number
 //      Revision
-[assembly: AssemblyFileVersion("1.2.2.0")]
-[assembly: AssemblyInformationalVersion("1.2.2.0")]
+[assembly: AssemblyFileVersion("1.2.2.1")]
+[assembly: AssemblyInformationalVersion("1.2.2.1")]
 
 // Change AssemblyVersion for breaking api changes
 // http://stackoverflow.com/questions/64602/what-are-differences-between-assemblyversion-assemblyfileversion-and-assemblyin

--- a/Regtesting.sln
+++ b/Regtesting.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegTesting.LocalTest", "Reg
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegTesting.Tests.Core", "RegTesting.Tests.Core\RegTesting.Tests.Core.csproj", "{6EAFA536-480C-46E2-8D5D-8DD58646DA2C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegTesting.Tests.Framework.UnitTests", "RegTesting.Tests.Framework.UnitTests\RegTesting.Tests.Framework.UnitTests.csproj", "{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -121,6 +123,16 @@ Global
 		{6EAFA536-480C-46E2-8D5D-8DD58646DA2C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{6EAFA536-480C-46E2-8D5D-8DD58646DA2C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{6EAFA536-480C-46E2-8D5D-8DD58646DA2C}.Release|x86.ActiveCfg = Release|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{68B685DA-BC65-43E9-8E59-3C7F2FA0511E}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- PageObjectFactory can now return derivates of page elements.
- Bugfix for missing baseUrl in pageUrl of a new created PageObject.
