### PR TITLE
Add Testsuites support to Localtool

### DIFF
--- a/RegTesting.Contracts/Services/ILocalTestService.cs
+++ b/RegTesting.Contracts/Services/ILocalTestService.cs
@@ -25,12 +25,21 @@ namespace RegTesting.Contracts.Services
 		/// <returns>a enumerable of languages</returns>
 		[OperationContract]
 		IEnumerable<LanguageDto> GetLanguages();
+
 		/// <summary>
 		/// Get browsers
 		/// </summary>
 		/// <returns>a enumerable of browsers</returns>
 		[OperationContract]
 		IEnumerable<BrowserDto> GetBrowsers();
+
+		/// <summary>
+		/// Get testsuites
+		/// </summary>
+		/// <returns>a enumerable of testsuites</returns>
+		[OperationContract]
+		IEnumerable<TestsuiteDto> GetTestsuites();
+
 		/// <summary>
 		/// add a local test task
 		/// </summary>
@@ -42,5 +51,17 @@ namespace RegTesting.Contracts.Services
 		/// <param name="languages">the languages</param>
 		[OperationContract]
 		void AddLocalTestTasks(string userName, string testsystemName, string testsystemUrl, List<string> browsers, List<string> testcases, List<string> languages);
+
+		/// <summary>
+		/// start a testsuite via localtool
+		/// </summary>
+		/// <param name="testsystemName">the testsystem</param>
+		/// <param name="userName">the releasemanager</param>
+		/// <param name="testsuiteName">the testsuite</param>
+		/// <param name="testsystemUrl">the testurl</param>
+		[OperationContract]
+		void AddTestsuiteTask(string userName, string testsystemName, string testsystemUrl, string testsuiteName);
+	
+	
 	}
 }

--- a/RegTesting.LocalTest/GUI/MainWindow.xaml
+++ b/RegTesting.LocalTest/GUI/MainWindow.xaml
@@ -11,26 +11,22 @@
             <ColumnDefinition Width="439*"/>
         </Grid.ColumnDefinitions>
         <controls:Grid Name="objRunningTestGrid" Visibility="Collapsed" Grid.ColumnSpan="2">
-            <controls:Grid.RowDefinitions>
-                <controls:RowDefinition Height="Auto" />
-                <controls:RowDefinition Height="*" />
+			<controls:Grid.RowDefinitions>
+				<controls:RowDefinition Height="*" />
                 <controls:RowDefinition Height="28" />
             </controls:Grid.RowDefinitions>
-            <controls:Grid.ColumnDefinitions>
-                <controls:ColumnDefinition Width="*" />
-            </controls:Grid.ColumnDefinitions>
-            <controls:Label controls:Grid.Row="0" controls:Grid.Column="0" Name="txtTestInfo" x:FieldModifier="private"  Margin="3" />
-            <controls:TextBox controls:Grid.Row="1" controls:Grid.Column="0" Name="txtTestStatus" x:FieldModifier="private" IsReadOnly="True" Margin="3" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" />
-            <controls:Button controls:Grid.Row="2" Content="Back"  controls:Grid.Column="0" Click="BtnBackClick"  Margin="3" />
+			<controls:Grid.ColumnDefinitions>
+				<controls:ColumnDefinition Width="*" />
+			</controls:Grid.ColumnDefinitions>
+			<controls:TextBox controls:Grid.Row="0" controls:Grid.Column="0" Name="txtTestStatus" x:FieldModifier="private" IsReadOnly="True" Margin="3" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" />
+            <controls:Button controls:Grid.Row="1" Content="Back"  controls:Grid.Column="0" Click="BtnBackClick"  Margin="3" />
         </controls:Grid>
         <controls:Grid Name="objTestGrid" Grid.ColumnSpan="2">
             <controls:Grid.RowDefinitions>
                 <controls:RowDefinition Height="28" />
                 <controls:RowDefinition Height="28" />
-                <controls:RowDefinition Height="*" />
-                <controls:RowDefinition Height="28" />
-                <controls:RowDefinition Height="200" />
-            </controls:Grid.RowDefinitions>
+				<controls:RowDefinition Height="*" />
+			</controls:Grid.RowDefinitions>
             <controls:Grid.ColumnDefinitions>
                 <controls:ColumnDefinition Width="Auto" />
                 <controls:ColumnDefinition Width="*" />
@@ -52,33 +48,65 @@
 
             </controls:Grid>
 
+			<controls:Label controls:Grid.Row="1" controls:Grid.Column="0" Content="Testsystem:"/>
+			<controls:TextBox controls:Grid.Row="1" controls:Grid.Column="1" Text="" Name="txtTestsystem" x:FieldModifier="private"  Margin="3" />
+
+			<TabControl  controls:Grid.Row="2" controls:Grid.Column="0"  Grid.ColumnSpan="2">
+				<TabItem Header="Custom">
+					<Grid>
+						<controls:Grid.RowDefinitions>
+							<controls:RowDefinition Height="28" />
+							<controls:RowDefinition Height="*" />
+							<controls:RowDefinition Height="200" />
+						</controls:Grid.RowDefinitions>
+						<controls:Grid.ColumnDefinitions>
+							<controls:ColumnDefinition Width="Auto" />
+							<controls:ColumnDefinition Width="*" />
+						</controls:Grid.ColumnDefinitions>
+
+						<controls:Label controls:Grid.Row="0" controls:Grid.Column="0" Content="Filter:"/>
+						<controls:TextBox controls:Grid.Row="0" controls:Grid.Column="1" Text="" Name="txtFilter" x:FieldModifier="private"  Margin="3" TextChanged="TxtFilter_OnTextChanged" />
+						<controls:ListBox controls:Grid.Row="1" controls:Grid.Column="0" controls:Grid.ColumnSpan="2" Name="lstViewTestcases" x:FieldModifier="private"  Margin="3" SelectionMode="Extended">
+						</controls:ListBox>
 
 
-            <controls:Label controls:Grid.Row="1" controls:Grid.Column="0" Content="Filter:"/>
-            <controls:TextBox controls:Grid.Row="1" controls:Grid.Column="1" Text="" Name="txtFilter" x:FieldModifier="private"  Margin="3" TextChanged="TxtFilter_OnTextChanged" />
-            <controls:ListBox controls:Grid.Row="2" controls:Grid.Column="0" controls:Grid.ColumnSpan="2" Name="lstViewTestcases" x:FieldModifier="private"  Margin="3" SelectionMode="Extended">
-            </controls:ListBox>
-
-            <controls:Label controls:Grid.Row="3" controls:Grid.Column="0" Content="Testsystem:"/>
-            <controls:TextBox controls:Grid.Row="3" controls:Grid.Column="1" Text="" Name="txtTestsystem" x:FieldModifier="private"  Margin="3" />
-            <controls:Grid controls:Grid.Row="4" controls:Grid.Column="0" controls:Grid.ColumnSpan="2">
-                <controls:Grid.RowDefinitions>
-                    <controls:RowDefinition Height="28" />
-                    <controls:RowDefinition Height="*" />
-                    <controls:RowDefinition Height="28" />
-                </controls:Grid.RowDefinitions>
-                <controls:Grid.ColumnDefinitions>
-                    <controls:ColumnDefinition Width="*" />
-                    <controls:ColumnDefinition Width="*" />
-                </controls:Grid.ColumnDefinitions>
+						<controls:Grid controls:Grid.Row="2" controls:Grid.Column="0" controls:Grid.ColumnSpan="2">
+							<controls:Grid.RowDefinitions>
+								<controls:RowDefinition Height="28" />
+								<controls:RowDefinition Height="*" />
+								<controls:RowDefinition Height="28" />
+							</controls:Grid.RowDefinitions>
+							<controls:Grid.ColumnDefinitions>
+								<controls:ColumnDefinition Width="*" />
+								<controls:ColumnDefinition Width="*" />
+							</controls:Grid.ColumnDefinitions>
 
 
-                <controls:Label controls:Grid.Row="0" controls:Grid.Column="0" Content="Language:"/>
-                <controls:ListBox controls:Grid.Row="1" controls:Grid.Column="0" Name="languages" x:FieldModifier="private"  Margin="3" SelectionMode="Extended"/>
-                <controls:Label controls:Grid.Row="0" controls:Grid.Column="1" Content="Browser:"/>
-                <controls:ListBox controls:Grid.Row="1" controls:Grid.Column="1" Name="lstBrowser" x:FieldModifier="private"  Margin="3" SelectionMode="Extended" />
-                <controls:Button controls:Grid.Row="2" controls:Grid.Column="0" controls:Grid.ColumnSpan="2" Content="Start Test" Click="BtnStartClick"  Margin="3" />
-            </controls:Grid>
+							<controls:Label controls:Grid.Row="0" controls:Grid.Column="0" Content="Language:"/>
+							<controls:ListBox controls:Grid.Row="1" controls:Grid.Column="0" Name="languages" x:FieldModifier="private"  Margin="3" SelectionMode="Extended"/>
+							<controls:Label controls:Grid.Row="0" controls:Grid.Column="1" Content="Browser:"/>
+							<controls:ListBox controls:Grid.Row="1" controls:Grid.Column="1" Name="lstBrowser" x:FieldModifier="private"  Margin="3" SelectionMode="Extended" />
+							<controls:Button controls:Grid.Row="2" controls:Grid.Column="0" controls:Grid.ColumnSpan="2" Content="Start Test" Click="BtnStartClick"  Margin="3" />
+						</controls:Grid>
+
+					</Grid>
+				</TabItem>
+				<TabItem Header="Testsuite">
+					<Grid>
+						<controls:Grid.RowDefinitions>
+							<controls:RowDefinition Height="*" />
+							<controls:RowDefinition Height="28" />
+						</controls:Grid.RowDefinitions>
+						<controls:Grid.ColumnDefinitions>
+							<controls:ColumnDefinition Width="*" />
+						</controls:Grid.ColumnDefinitions>
+
+						<controls:ListBox controls:Grid.Row="0" controls:Grid.Column="0" Name="Testsuites" x:FieldModifier="private"  Margin="3"/>
+						<controls:Button controls:Grid.Row="1" controls:Grid.Column="0" Content="Start Test" Click="BtnStartTestsuiteClick"  Margin="3" />
+
+					</Grid>
+				</TabItem>
+			</TabControl>
 
 
         </controls:Grid>

--- a/RegTesting.LocalTest/GUI/MainWindow.xaml.cs
+++ b/RegTesting.LocalTest/GUI/MainWindow.xaml.cs
@@ -234,16 +234,17 @@ namespace RegTesting.LocalTest.GUI
 
 		private void GetRemoteCapability()
 		{
+			try
+			{
+				List<string> remoteBrowsers;
+				List<string> remoteLanguages;
+				List<string> remoteTestsuites;
 
-			List<string> remoteLanguages;
-			List<string> remoteBrowsers;
-
-
-			try {
 				using (WcfClient wcfClient = new WcfClient())
 				{
 					remoteLanguages = wcfClient.GetLanguages();
 					remoteBrowsers = wcfClient.GetBrowsers();
+					remoteTestsuites = wcfClient.GetTestsuites();
 
 				}
 				Dispatcher.Invoke((() =>
@@ -262,18 +263,19 @@ namespace RegTesting.LocalTest.GUI
 
 						lstBrowser.Items.Add(checkBoxRow);
 					}
-				
+
 					lstBrowser.Items.Refresh();
 					languages.Items.Refresh();
+					Testsuites.Items.Clear();
+					remoteTestsuites.ForEach(t => Testsuites.Items.Add(t));
 					remoteAvailable = true;
 
 				}));
-			} catch {
+			}
+			catch
+			{
 				remoteAvailable = false;
 			}
-	
-
-
 		}
 
 		void browserCheckBoxRow_Click(object sender, RoutedEventArgs e)
@@ -466,6 +468,24 @@ namespace RegTesting.LocalTest.GUI
 					MessageBoxButtons.OK,
 					MessageBoxIcon.Exclamation,
 					MessageBoxDefaultButton.Button1);
+		}
+
+		private void BtnStartTestsuiteClick(object sender, RoutedEventArgs e)
+		{
+			if (Testsuites.SelectedItems.Count != 1)
+			{
+				ShowErrorMessage("You must select one testsuite first.", "Missing arguments!");
+				return;
+			}
+
+			string testsuite = Testsuites.SelectedItem.ToString();
+			string testsystem = txtTestsystem.Text;
+			string fileName = txtFile.Text;
+
+			using (WcfClient wcfClient = new WcfClient())
+			{
+				wcfClient.TestRemote(fileName, testsystem, testsuite);
+			}
 		}
 	}
 

--- a/RegTesting.LocalTest/Logic/WcfClient.cs
+++ b/RegTesting.LocalTest/Logic/WcfClient.cs
@@ -85,6 +85,18 @@ namespace RegTesting.LocalTest.Logic
 		}
 
 		/// <summary>
+		/// Get all (non local) testsuites
+		/// </summary>
+		/// <returns>A list of string with all testsuites</returns>
+		public List<string> GetTestsuites()
+		{
+			List<string> testsuites = _channel.GetTestsuites().Where(t=>!t.Name.StartsWith("Local")).Select(t => t.Name).ToList();
+			testsuites.Sort();
+			return testsuites;
+
+		}
+
+		/// <summary>
 		/// Start Tests at the Remote Server
 		/// </summary>
 		/// <param name="fileName">the filename of the testfile</param>
@@ -104,6 +116,25 @@ namespace RegTesting.LocalTest.Logic
 			_channel.AddLocalTestTasks(username, testsystemName, testsystemUrl, browsers, testcases, languages);
 			int testsCount = browsers.Count*testcases.Count*languages.Count;
 			System.Windows.MessageBox.Show(String.Format("Requested {0} tests on {1}. You'll receive a mail when your results are ready!" , testsCount, testsystemUrl));
+		}
+
+		/// <summary>
+		/// Start a testsuite at the Remote Server
+		/// </summary>
+		/// <param name="fileName">the filename of the testfile</param>
+		/// <param name="testsystemUrl">the testsystem url</param>
+		/// <param name="testsuite">the testsuite</param>
+		public void TestRemote(string fileName, string testsystemUrl, string testsuite)
+		{
+			testsystemUrl = testsystemUrl.ToLower().Replace("https://", "").Replace("http://", "");
+
+			string username = GetUser();
+			string testsystemName = "local/" + testsystemUrl + "-" + username;
+
+
+			SendFile(fileName, testsystemName);
+			_channel.AddTestsuiteTask(username, testsystemName, testsystemUrl,testsuite);
+			System.Windows.MessageBox.Show(String.Format("Requested Testsuite {0}. You'll receive a mail when your results are ready!",  testsuite));
 		}
 	}
 }


### PR DESCRIPTION
Added tabs to localtool. Beside the old custom mode, a testsuite mode is added.
In testsuite mode, a testsuite can be started on the remote server.
