### PR TITLE
CreatePageUrlWithParameters should return PageUrl

### DIFF
--- a/RegTesting.Tests.Framework/Logic/BasePageObject.cs
+++ b/RegTesting.Tests.Framework/Logic/BasePageObject.cs
@@ -44,7 +44,7 @@ namespace RegTesting.Tests.Framework.Logic
 
 		public virtual string CreatePageUrlWithParameters(IEnumerable<string> urlParams)
 		{
-			return string.Empty;
+			return PageUrl;
 		}
 
 		public void HandleAlert(bool accept)


### PR DESCRIPTION
CreatePageUrlWithParameters should return PageUrl instead of String.Empty
