### PR TITLE
RunBeforeTestStart Interface and TestContext

### DIFF
--- a/RegTesting.Tests.Framework/Elements/BasicPageElement.cs
+++ b/RegTesting.Tests.Framework/Elements/BasicPageElement.cs
@@ -51,7 +51,7 @@ namespace RegTesting.Tests.Framework.Elements
 			By = byLocator;
 			WebDriver = webDriver;
 			ParentPageObject = parentPageObject;
-			ClickBehaviour = ClickBehaviourFactory.Create(clickBehaviour, this);
+			ClickBehaviour = TestContext.ClickBehaviourFactory.Create(clickBehaviour, this);
 		}
 
 		/// <summary>

--- a/RegTesting.Tests.Framework/Elements/Input.cs
+++ b/RegTesting.Tests.Framework/Elements/Input.cs
@@ -14,7 +14,7 @@ namespace RegTesting.Tests.Framework.Elements
 		public Input(By objBy, IWebDriver webDriver, WaitModel waitModel, BasePageObject parentPageObject, ClickBehaviours clickBehaviour = ClickBehaviours.Default, FillBehaviour fillBehaviour = FillBehaviour.Default)
 			: base(objBy, webDriver, waitModel, parentPageObject, clickBehaviour)
 		{
-			_fillBehaviour = FillbehaviourFactory.Create(fillBehaviour, this);
+			_fillBehaviour = TestContext.FillBehaviourFactory.Create(fillBehaviour, this);
 		}
 
 		public void Type(string text)

--- a/RegTesting.Tests.Framework/Logic/ClickBehaviourFactory.cs
+++ b/RegTesting.Tests.Framework/Logic/ClickBehaviourFactory.cs
@@ -4,9 +4,9 @@ using RegTesting.Tests.Framework.Enums;
 
 namespace RegTesting.Tests.Framework.Logic
 {
-	public class ClickBehaviourFactory
+	public class ClickBehaviourFactory : IClickBehaviourFactory
 	{
-		public static IClickable Create(ClickBehaviours clickBehaviour, BasicPageElement pageElement)
+		IClickable IClickBehaviourFactory.Create(ClickBehaviours clickBehaviour, BasicPageElement pageElement)
 		{
 			switch (clickBehaviour)
 			{

--- a/RegTesting.Tests.Framework/Logic/FillbehaviourFactory.cs
+++ b/RegTesting.Tests.Framework/Logic/FillbehaviourFactory.cs
@@ -3,9 +3,9 @@ using RegTesting.Tests.Framework.Enums;
 
 namespace RegTesting.Tests.Framework.Logic
 {
-	public class FillbehaviourFactory
+	public class FillBehaviourFactory : IFillBehaviourFactory
 	{
-		public static IFillable Create(FillBehaviour fillBehaviour, BasicPageElement pageElement)
+		IFillable IFillBehaviourFactory.Create(FillBehaviour fillBehaviour, BasicPageElement pageElement)
 		{
 			switch (fillBehaviour)
 			{

--- a/RegTesting.Tests.Framework/Logic/IClickBehaviourFactory.cs
+++ b/RegTesting.Tests.Framework/Logic/IClickBehaviourFactory.cs
@@ -1,0 +1,12 @@
+﻿using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+
+namespace RegTesting.Tests.Framework.Logic
+{
+	public interface IClickBehaviourFactory
+	{
+		IClickable Create(ClickBehaviours clickBehaviour, BasicPageElement pageElement);
+
+	}
+
+}

--- a/RegTesting.Tests.Framework/Logic/IFillBehaviourFactory.cs
+++ b/RegTesting.Tests.Framework/Logic/IFillBehaviourFactory.cs
@@ -1,0 +1,11 @@
+﻿using RegTesting.Tests.Framework.Elements;
+using RegTesting.Tests.Framework.Enums;
+
+namespace RegTesting.Tests.Framework.Logic
+{
+	public interface IFillBehaviourFactory
+	{
+		IFillable Create(FillBehaviour fillBehaviour, BasicPageElement pageElement);
+	}
+
+}

--- a/RegTesting.Tests.Framework/Logic/IRunBeforeTestStart.cs
+++ b/RegTesting.Tests.Framework/Logic/IRunBeforeTestStart.cs
@@ -1,0 +1,10 @@
+﻿namespace RegTesting.Tests.Framework.Logic
+{
+	/// <summary>
+	/// Interface to have classes run a method before the test execution
+	/// </summary>
+	public interface IRunBeforeTestStart
+	{
+		void Run();
+	}
+}

--- a/RegTesting.Tests.Framework/Logic/TestContext.cs
+++ b/RegTesting.Tests.Framework/Logic/TestContext.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RegTesting.Tests.Framework.Elements;
+
+namespace RegTesting.Tests.Framework.Logic
+{
+	/// <summary>
+	/// The TestContext
+	/// </summary>
+	public static class TestContext
+	{
+		/// <summary>
+		/// The click behaviour factory
+		/// </summary>
+		public static IClickBehaviourFactory ClickBehaviourFactory = new ClickBehaviourFactory();
+
+		/// <summary>
+		/// The fill behaviour factory
+		/// </summary>
+		public static IFillBehaviourFactory FillBehaviourFactory = new FillBehaviourFactory();
+
+	}
+}

--- a/RegTesting.Tests.Framework/Properties/AssemblyInfo.cs
+++ b/RegTesting.Tests.Framework/Properties/AssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 //      Minor Version 
 //      Build Number
 //      Revision
-[assembly: AssemblyFileVersion("1.3.2.0")]
-[assembly: AssemblyInformationalVersion("1.3.2.0")]
+[assembly: AssemblyFileVersion("1.3.3.0")]
+[assembly: AssemblyInformationalVersion("1.3.3.0")]
 
 // Change AssemblyVersion for breaking api changes
 // http://stackoverflow.com/questions/64602/what-are-differences-between-assemblyversion-assemblyfileversion-and-assemblyin

--- a/RegTesting.Tests.Framework/RegTesting.Tests.Framework.csproj
+++ b/RegTesting.Tests.Framework/RegTesting.Tests.Framework.csproj
@@ -83,13 +83,17 @@
     <Compile Include="Logic\Extensions\WebElementExtensions.cs" />
     <Compile Include="Logic\FillBehaviourAttribute.cs" />
     <Compile Include="Logic\FillbehaviourFactory.cs" />
+    <Compile Include="Logic\IClickBehaviourFactory.cs" />
+    <Compile Include="Logic\IFillBehaviourFactory.cs" />
     <Compile Include="Logic\Init\IWebDriverFactory.cs" />
     <Compile Include="Logic\Init\LocalWebDriverFactory.cs" />
     <Compile Include="Logic\Init\RemoteWebDriverFactory.cs" />
+    <Compile Include="Logic\IRunBeforeTestStart.cs" />
     <Compile Include="Logic\LocateAttribute.cs" />
     <Compile Include="Logic\PageObjectFactory.cs" />
     <Compile Include="Logic\PartialPageObjectAttribute.cs" />
     <Compile Include="Logic\SupportedResolutions.cs" />
+    <Compile Include="Logic\TestContext.cs" />
     <Compile Include="Logic\Testlog.cs" />
     <Compile Include="Logic\TestStatusManager.cs" />
     <Compile Include="Logic\WaitAttribute.cs" />


### PR DESCRIPTION
The RunBeforeTestStart interface is to declare classes that runs some code before each test.
Use the testContext to define your own clickBehaviour and fillBehaviour factories used during the test.
